### PR TITLE
Cleanups from TBL meeting Nov 5 2017

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -1,9 +1,0 @@
-## Data wrangling and visualization with Python and [Smartdown](https://smartdown.site/)
-### Parking violation data of Eugene, OR, 2007-2008
-
-1.[Raw Data](:@Rawdata)
-2.[Clean And Transform Data](:@Cleantransformdata)
-3.[Geocoding Addresses](:@Geocoding)
-4.[Map with marker](:@Mapwmarker)
-5.[Map with trendline 1](:@Mapwtrendline1)
-6.[Map with trendline 2](:@Mapwtrendline2)

--- a/index.html
+++ b/index.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+  <head>
     <meta charset="utf-8">
     <title>Smartdown Grid Layout (using vue-grid-layout) </title>
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
+
     <link rel="stylesheet" href="vuegridlayout.css">
     <link rel="stylesheet" href="https://unpkg.com/smartdown/docs/lib/smartdown.css">
 
@@ -14,33 +15,30 @@
     <script src="https://unpkg.com/vue/dist/vue.js"></script>
 
     <script src="https://unpkg.com/vue-grid-layout/dist/vue-grid-layout.min.js"></script>
-
-<!-- 
-    <script src="vgldebug/vue-grid-layout.js"></script>
- -->
-
     <script src="https://smartdown.site/lib/smartdown.js"></script>
-</head>
+  </head>
 
-<body
-  class="container container-fluid"
-  id="bodyID">
-    <div
+  <body
+    class="container container-fluid"
+    id="bodyID">
+      <div
         v-cloak
         v-bind:class="{ 'disable-select': isDragging() }"
         id="layoutApp">
-        <div class="layoutJSON">
+
+        <div
+          class="layoutJSON">
           <div class="row">
-            <div class="col-xs-3">
+            <div class="col-xs-9">
+              <button
+                v-for="t in tableaux"
+                class="btn btn-default btn-xs"
+                v-on:click="loadTableau(t)">
+                {{t}}
+              </button>
+            </div>
+            <div class="col-xs-3" v-if="!kioskMode">
               <input type="checkbox" v-model="showSettings"/>&nbsp;Settings
-            </div>
-            <div class="col-xs-7">
-              <button class="btn btn-default btn-xs" v-on:click="loadTableau('welcome')">Welcome</button>
-              <button class="btn btn-default btn-xs" v-on:click="loadTableau('comic')">Comic</button>
-              <button class="btn btn-default btn-xs" v-on:click="loadTableau('gallery')">Gallery (buggy)</button>
-            </div>
-            <div class="col-xs-2">
-              <button class="btn btn-default btn-xs" v-on:click="fixLayout">Fix</button>
             </div>
           </div>
           <div class="row" v-if="showSettings">
@@ -51,23 +49,6 @@
             </div>
             <div class="col-xs-8">
               <div class="row">
-                <div>
-                  <button class="btn btn-default btn-xs" v-on:click="applySmartdown">Apply Content</button>
-                  <br>
-                  <input type="checkbox" v-model="draggable"/> Draggable
-                  <input type="checkbox" v-model="resizable"/> Resizable
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="col-xs-12">
-                  <button class="btn btn-default btn-xs" v-on:click="switchToColumnLayout">Column Layout</button>
-                  <button class="btn btn-default btn-xs" v-on:click="switchToRowLayout">Row Layout</button>
-                  <button class="btn btn-default btn-xs" v-on:click="exportTableau">Export Tableau</button>
-                </div>
-              </div>
-
-              <div class="row">
                 <div class="col-xs-12">
                   <input
                     type="file"
@@ -77,6 +58,26 @@
                     multiple/>
                 </div>
               </div>
+              <div class="row">
+                <div class="col-xs-12">
+                  <button class="btn btn-default btn-xs" v-on:click="switchToColumnLayout">Column Layout</button>
+                  <button class="btn btn-default btn-xs" v-on:click="switchToRowLayout">Row Layout</button>
+                  <button class="btn btn-default btn-xs" v-on:click="exportTableau">Export Tableau</button>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-xs-8">
+                  <input type="checkbox" v-model="draggable"/> Draggable
+                  <input type="checkbox" v-model="resizable"/> Resizable
+                </div>
+
+                <div class="col-xs-4">
+                  <button class="btn btn-default btn-xs" v-on:click="fixLayout">Fix</button>
+                </div>
+
+              </div>
+
+
             </div>
           </div>
         </div>
@@ -86,7 +87,7 @@
                         :layout="layout"
                         :col-num="numCols"
                         :row-height="rowHeight"
-                        :margin="[10, 10]"
+                        :margin="[3, 3]"
                         :is-draggable="draggable"
                         :is-resizable="resizable"
                         :vertical-compact="true"
@@ -116,24 +117,21 @@
       </div>
     </div>
 
-    <div class="footer">
-      <div class="row">
-        <div class="text-center col-xs-6">
-          <a
-            href="https://github.com/jbaysolutions/vue-grid-layout"
-            target="_blank">
-            vue-grid-layout on Github
-          </a>
-        </div>
-        <div class="text-center col-xs-6">
-          <a
-            href="https://github.com/DoctorBud/smartdown_vuegridlayout"
-            target="_blank">
-            smartdown_vuegridlayout on Github
-          </a>
-        </div>
-      </div>
-    </div>
-    <script src="sd_basic_grid.js"></script>
-</body>
+    <script>
+      //
+      // The options below control how the grid_helper behaves.
+      // They are designed to support publishing via bl.ocks.org, a blog, or Wordpress
+      //
+      //  kioskMode - 'true' means disable the Settings checkbox
+      //  tableaux - A list of names of tableaux in the tableaux/ directory
+      //  defaultTableauName - The tableau to load by default. Default is tableaux[0]
+      //
+      window.gridHelperOptions = {
+        kioskMode: true,
+        tableaux: ['Comic', 'Welcome'],
+        defaultTableauName: 'comic',
+      };
+    </script>
+    <script src="grid_helper.js"></script>
+  </body>
 </html>

--- a/tableaux/comic1.md
+++ b/tableaux/comic1.md
@@ -1,5 +1,6 @@
 ![](https://imgs.xkcd.com/comics/magic_tree_2x.png)
-[Magic Tree](https://xkcd.com/1569/)
+
+### [Magic Tree](https://xkcd.com/1569/)
 
 
 

--- a/tableaux/comic2.md
+++ b/tableaux/comic2.md
@@ -1,3 +1,4 @@
 ![](https://imgs.xkcd.com/comics/fire_2x.png)
-[Fire](https://xkcd.com/1794/)
+
+### [Fire](https://xkcd.com/1794/)
 

--- a/tableaux/comic3.md
+++ b/tableaux/comic3.md
@@ -1,5 +1,5 @@
 ![](https://imgs.xkcd.com/comics/science.jpg)
 
-[Science](https://xkcd.com/54/)
+### [Science](https://xkcd.com/54/)
 
 

--- a/tableaux/comic4.md
+++ b/tableaux/comic4.md
@@ -1,5 +1,5 @@
 ![](https://imgs.xkcd.com/comics/headache.png)
 
-[Headache](https://xkcd.com/880/)
+### [Headache](https://xkcd.com/880/)
 
 

--- a/tableaux/gallery.yaml
+++ b/tableaux/gallery.yaml
@@ -1,27 +1,27 @@
 layout:
   cells:
     - posX: 0
+      posY: 21
+      dimW: 6
+      dimH: 12
+      contentURL: 'https://smartdown.site/lib/gallery/Three.md'
+    - posX: 0
       posY: 0
+      dimW: 12
+      dimH: 21
+      contentURL: 'https://smartdown.site/lib/gallery/Math.md'
+    - posX: 0
+      posY: 33
       dimW: 6
-      dimH: 1
-      contentURL: https://smartdown.site/lib/gallery/README.md
+      dimH: 15
+      contentURL: 'https://smartdown.site/lib/gallery/Graphviz.md'
     - posX: 6
-      posY: 0
+      posY: 21
       dimW: 6
-      dimH: 1
-      contentURL: https://smartdown.site/lib/gallery/Math.md
-    - posX: 6
-      posY: 1
+      dimH: 28
+      contentURL: 'https://smartdown.site/lib/gallery/Maps.md'
+    - posX: 2
+      posY: 49
       dimW: 6
-      dimH: 1
-      contentURL: https://smartdown.site/lib/gallery/Graphviz.md
-    - posX: 6
-      posY: 2
-      dimW: 6
-      dimH: 1
-      contentURL: https://smartdown.site/lib/gallery/Maps.md
-    - posX: 6
-      posY: 3
-      dimW: 6
-      dimH: 1
-      contentURL: https://smartdown.site/lib/gallery/P5JS.md
+      dimH: 16
+      contentURL: 'https://smartdown.site/lib/gallery/P5JS.md'

--- a/vuegridlayout.css
+++ b/vuegridlayout.css
@@ -49,8 +49,6 @@ div#layoutApp .vue-grid-layout .vue-grid-item {
   margin: 0;
   width: 100%;
   height: 100%;
-  overflow-y: auto;
-  overflow-x: hidden;
 }
 
 div#layoutApp .vue-grid-layout .vue-grid-item:not(.vue-grid-placeholder) {
@@ -90,6 +88,8 @@ div.no-drag.smartdown-tile {
   background: ghostwhite;
   margin: 0;
   padding: 5px;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 div.no-drag.smartdown-tile:empty {


### PR DESCRIPTION
- Deleted Home.md, which should never have been added.
- Added compile-time parameter enforceMaxHeight to force fitContent() on any resize, effectively allowing only horizontal adjustment, which isn't a bad thing.
- Added respect for window.gridHelperOptions to allow the reusable grid_helper.js to be configured prior to inclusion.
- Added a window resize listener so that fitContent() occurs on resize.
- Moved isDragging() to being a method instead of a data: item.
- Renamed sd_basic_grid.js to grid_helper.js, to be more in conformance with Smartdown's blocks_helper.js and inline_helper.js...
- Remember, we want to unify all these _helper.js eventually, with parametric differences only between their various deployments (bl.ocks.org, Wordpress, BlogKit).
- Adjusted Settings layout to enable a KioskMode, which presents only the ability to select from a set of tableaux.
- Fixed the bug where we were height-limiting a grid cell in fitContent(), but leaving behind a big gray area.