### PR TITLE
Sdgrid card navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,15 @@
             <div class="col-xs-3" v-if="!kioskMode">
               <input type="checkbox" v-model="showSettings"/>&nbsp;Settings
             </div>
+            <div class="col-xs-9" v-if="kioskMode">
+              <button
+                v-for="item in layout"
+                class="btn btn-default btn-xs card-button"
+                v-bind:class="{ focused: isSdTileInFocus(item.contentURL.split('/')[1]) }"
+                v-on:click="focusOnCard(item.contentURL.split('/')[1])">
+                {{item.contentURL.split('/')[1]}}
+              </button>
+            </div>
           </div>
           <div class="row" v-if="showSettings">
             <div class="col-xs-4">
@@ -50,7 +59,7 @@
             </div>
             <div class="col-xs-8">
               <div class="row">
-                <div class="col-xs-12">
+                <div class="col-xs-12" v-if="authorMode">
                   <input
                     type="file"
                     id="sdSelection"
@@ -111,7 +120,8 @@
               </div>
               <div
                 class="no-drag smartdown-tile"
-                v-bind:id="item.divID">
+                v-bind:id="item.divID"
+                v-bind:class="{ 'in-focus': isSdTileInFocus(item.contentURL.split('/')[1]) }">
               </div>
             </grid-item>
           </grid-layout>
@@ -129,6 +139,7 @@
       //
       window.gridHelperOptions = {
         kioskMode: true,
+        authorMode: false,
         tableaux: ['Comic', 'Welcome'],
         defaultTableauName: 'Comic',
       };

--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@
           class="layoutJSON">
           <div class="row">
             <div class="col-xs-9">
+              <input type="checkbox" v-model="kioskMode"/> kioskMode
+              <input type="checkbox" v-model="authorMode"/> authorMode
               <button
                 v-for="t in tableaux"
                 class="btn btn-default btn-xs tableau-button"
@@ -41,7 +43,7 @@
             <div class="col-xs-3" v-if="!kioskMode">
               <input type="checkbox" v-model="showSettings"/>&nbsp;Settings
             </div>
-            <div class="col-xs-9" v-if="kioskMode">
+            <div class="col-xs-9" v-if="kioskMode&!authorMode">
               <button
                 v-for="item in layout"
                 class="btn btn-default btn-xs card-button"
@@ -59,7 +61,7 @@
             </div>
             <div class="col-xs-8">
               <div class="row">
-                <div class="col-xs-12" v-if="authorMode">
+                <div class="col-xs-12" v-if="authorMode&!kioskMode">
                   <input
                     type="file"
                     id="sdSelection"

--- a/vuegridlayout.css
+++ b/vuegridlayout.css
@@ -34,6 +34,17 @@ div#layoutApp .layoutJSON {
   padding: 5px 10px;
 }
 
+.layoutJSON button.card-button {
+  margin: 2px 5px;
+  padding: 1px 3px;
+}
+
+.layoutJSON button.card-button.focused {
+  background: yellow;
+  margin: 1px 3px;
+  padding: 2px 5px;
+}
+
 input#sdSelection {
 }
 
@@ -96,9 +107,18 @@ div#layoutApp .vue-grid-layout .vue-grid-item .no-drag {
 }
 
 div.no-drag.smartdown-tile {
-  background: ghostwhite;
+  background: lightgrey;/*ghostwhite;*/
   margin: 0;
   padding: 5px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+div.no-drag.smartdown-tile.in-focus {
+  background: white;
+  margin: 0;
+  padding: 0px;
+  border: 1px red;
   overflow-y: auto;
   overflow-x: hidden;
 }


### PR DESCRIPTION
* Toggle available functionalities with 'kioskMode' and 'authorMode' input buttons;
* Added card navigation buttons (only visible when app is in 'kioskMode' and not in 'authorMode');
* When focusing on one card, the corresponding div shows a lighter background and smaller padding; - I wanted to also change the border thickness and color but haven't gotten it to work yet.
* When focusing on one card, the corresponding card button turns yellow and the window's location hash reflects both the tableau and the card in focus;
* Ability to bookmark a page with a hash containing both the tableau and the card; 
* Card navigation/focusing only works for cards loaded from a tableau at the moment (these have the 'contentURL' field in layout), it doesn't work for sd content loaded from fileReader;
* Window location hash a bit buggy for switching between cards 'kioskMode' and 'authorMode' (when in 'authorMode' a hash with both tableau name and card name will not load.