### PR TITLE
Refactored grid_helper.js to DRY it up. Style and Navigation Fixes.

### DIFF
--- a/grid_helper.js
+++ b/grid_helper.js
@@ -1,225 +1,179 @@
-//const authorMode = true;
-const enforceMaxHeight = false;
+/* global smartdown */
+/* global VueGridLayout */
+/* global jsyaml */
+/* eslint no-unused-vars: 0 */
 
-
-var debugCard0 =
-`
-### Welcome to Debug Card 0
-
-[What is your name?](:?Name)
-
-#### A Few of My Favorite Things
-
-- Raindrops on Roses
-- Whiskers on Kittens
-- Bright copper kettles
-- Warm woollen mittens
-- Brown paper packages tied up with strings
-
-`;
-
-var debugCard1 =
-`
-### Welcome to Debug Card 1
-
-Pleasant to meet you, [](:!Name)
-
----
-
-#### Raindrops on Roses
-
-![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Raindrops_red_rose.jpg/240px-Raindrops_red_rose.jpg)
-
-`;
-
-var debugCard2 =
-`
-### Welcome to Debug Card 2
-
-
-\`\`\`p5js/playable/autoplay
-var PI = Math.PI;
-var HALF_PI = PI / 2.0;
-var SEGMENTS = env.SEGMENTS || 50;  // number of segments
-var SEG_WIDTH = env.SEG_WIDTH || 8;
-var SEG_LENGTH = env.SEG_LENGTH || 100;
-var DIAMETER = SEG_LENGTH * 2;
-var speed = 0.05;
-var ax = .01;
-var ay = ax;
-var az = ay;
-var dx, dy, dz;
-
-p5.setup = function() {
-  dx = p5.random(-speed, speed);
-  dy = p5.random(-speed, speed);
-  dz = p5.random(-speed, speed);
-
-  p5.createCanvas(200, 200, 'webgl');
-  p5.normalMaterial();
-
-  p5.frameRate(35);
-};
-
-p5.draw = function() {
-  p5.background('ivory');
-  p5.camera(0, SEG_LENGTH, SEG_LENGTH, 0, 0, 0, 0, 1, 0);
-  p5.rotateX(ax += dx);
-  p5.rotateY(ay += dy);
-  p5.rotateZ(az += dz);
-
-  for (var i = 0; i < SEGMENTS; i++) {
-    var frac = i * 2 / SEGMENTS;
-    p5.push();
-    p5.rotateX(frac * HALF_PI);
-    p5.rotateY(HALF_PI);
-    p5.translate(
-        0,
-        DIAMETER * p5.cos(frac * HALF_PI),
-        DIAMETER * p5.sin(frac * PI));
-    p5.cylinder(SEG_WIDTH, SEG_LENGTH);
-    p5.pop();
-  }
-};
-\`\`\`
-
-
-`;
-var debugContent = [debugCard0, debugCard1, debugCard2];
-
-/*
-  var x = 0;
-
-  var y = x++;
-
-*/
-
-function updateSdSelection(sdContent, done) {
-  // !This is bad, how is a method within a view to know about DOM elements?!
-  var selectedFiles = document.getElementById('sdSelection').files;
-  sdContent.length = 0;
-  sdContent.length = selectedFiles.length;
-  var numItemsLeft = sdContent.length;
-  function updateSdContent(index) {
-    return function(event) {
-      var sdText = event.target.result;
-      sdContent[index] = sdText;
-      if (--numItemsLeft === 0) {
-        done();
-      }
-    };
-  }
-
-  for (var indexOfFile = 0; indexOfFile < selectedFiles.length; indexOfFile++) {
-    var reader = new FileReader();
-    reader.onloadend = updateSdContent(indexOfFile);
-    reader.readAsText(selectedFiles[indexOfFile]);
-  }
-}
 
 Vue.config.debug = true;
 Vue.config.devtools = true;
-/* global VueGridLayout */
+
 var GridLayout = VueGridLayout.GridLayout;
 var GridItem = VueGridLayout.GridItem;
 
-var gridView = null;
+//
+// work in progress to create a smartdown component and simplify applySmartdown()
+// and fitContent()
+// Requires smartdown 0.0.50
+//
+
+Vue.component('smartdown', {
+  props: ['content'],
+  template: '<div>Smartdown content: {{content}}</div>',
+  mounted() {
+    // console.log('mounted', this, this.$el.id, this.content);
+    smartdown.setSmartdown(this.content, this.$el);
+  },
+  updated() {
+    // console.log('updated', this, this.$el.id, this.content);
+    smartdown.setSmartdown(this.content, this.$el);
+  }
+});
+
+
+const enforceMaxHeight = false;
 const defaultRowHeight = 100;
 const numColumns = 12;
 const vueAppDivId = 'layoutApp';
 
+var availableTableaux = ['Welcome', 'Comic', 'Gallery', 'WebGL', 'Pegoda'];
 
-function buildStaggeredLayout(numOfSDContent, numCols) {
-  console.log('buildStaggeredLayout', numOfSDContent, numCols);
-  var width = numCols / numOfSDContent;
-  var height = 1;
-  var layout = Array(numOfSDContent);
-  let x = 0;
 
-  for (var index = 0; index < numOfSDContent; index++) {
-    let h = height * (index + 1);
-    layout[index] = {
-      "x": x,
-      "y": 0,
-      "w": width,
-      "h": h,
-      "i": index.toString(),
-      "divID": "smartdown-output" + index
-    };
+function buildLayout(numContent, xDelta, yDelta, width, widthDelta, height, heightDelta) {
+  xDelta = xDelta === undefined ? 0 : xDelta;
+  yDelta = yDelta === undefined ? 1 : yDelta;
+  width = width === undefined ? numColumns : width;
+  height = height === undefined ? 1 : height;
+  widthDelta = widthDelta === undefined ? -1 : widthDelta;
+  heightDelta = heightDelta === undefined ? 0 : heightDelta;
 
-    x += width;
+  var layout = [];
+
+  for (var index = 0; index < numContent; index++) {
+    let x = xDelta * index;
+    let y = yDelta * index;
+    let w = width + widthDelta * index;
+    let h = height + heightDelta * index;
+
+    if (x + w >= numColumns) {
+      ++y;
+      x = x % numColumns;
+    }
+    layout.push({
+      x: x,
+      y: y,
+      w: w,
+      h: h,
+      i: index.toString(),
+      divID: "smartdown-output" + index
+    });
   }
 
   return layout;
 }
 
 
+function buildXLayout(numContent) {
+  var numContentPerCorner = Math.floor((numContent - 1) / 4);
+  var layout = [];
+  var index = 0;
+  var w = 3;
 
-function buildColumnLayout(numOfSDContent, numCols) {
-  var width = numCols / numOfSDContent;
-  var height = 1;
-  var layout = Array(numOfSDContent);
-  let x = 0;
-
-  for (var index = 0; index < numOfSDContent; index++) {
-    //let w = width * 2 * (index + 1);
-    layout[index] = {
-      "x": x,
-      "y": 0,
-      "w": width,
-      "h": height,
-      "i": index.toString(),
-      "divID": "smartdown-output" + index
+  // UL corner
+  for (let i = 0; i < numContentPerCorner; ++i) {
+    let cell = {
+      x: i * w,
+      y: 0,
+      w: w,
+      h: 1,
+      i: index.toString(),
+      divID: "smartdown-output" + index
     };
+    layout.push(cell);
+    ++index;
+  }
 
-    x += width;
+  // UR corner
+  for (let i = 0; i < numContentPerCorner; ++i) {
+    let cell = {
+      x: numColumns - numContentPerCorner * w + (i * w),
+      y: 0,
+      w: w,
+      h: 1,
+      i: index.toString(),
+      divID: "smartdown-output" + index
+    };
+    layout.push(cell);
+    ++index;
+  }
+
+  // Center
+  let cell = {
+    x: 2,
+    y: 3,
+    w: 8,
+    h: 1,
+    i: index.toString(),
+    divID: "smartdown-output" + index
+  };
+  layout.push(cell);
+  ++index;
+
+  // LL corner
+  for (let i = 0; i < numContentPerCorner; ++i) {
+    let cell = {
+      x: i * w,
+      y: 6,
+      w: w,
+      h: 1,
+      i: index.toString(),
+      divID: "smartdown-output" + index
+    };
+    layout.push(cell);
+    ++index;
+  }
+
+  // LR corner
+  for (let i = 0; i < numContentPerCorner; ++i) {
+    let cell = {
+      x: numColumns - numContentPerCorner * w + (i * w),
+      y: 6,
+      w: w,
+      h: 1,
+      i: index.toString(),
+      divID: "smartdown-output" + index
+    };
+    layout.push(cell);
+    ++index;
   }
 
   return layout;
 }
 
 
-function buildRowLayout(numOfSDContent, numCols) {
-  //console.log("Switching to row layout");
-  var width = numCols;
-  var height = 1;
-  var layout = Array(numOfSDContent);
-  let y = 0;
-  for (var index = 0; index < numOfSDContent; index++) {
-    let h = height + index;
-    layout[index] = {
-      "x": 0,
-      "y": y,
-      "w": width,
-      "h": h,
-      "i": index.toString(),
-      "divID": "smartdown-output" + index
-    };
-    y += h;
-  }
-
-  return layout;
-}
-
-
-function fitContent(layout, rowHeight) {
-  layout.forEach(function(layoutElement, layoutElementIndex) {
+function fitContent(tableau, rowHeight, maxRows) {
+  var layout = tableau.layout.cells;
+  layout.forEach(function(layoutElement) {
     var divID = layoutElement.divID;
     var gridCellDiv = document.getElementById(divID);
-    var innerContainer = gridCellDiv.children[0];
-    if (!innerContainer) {
-      console.log('Error when adjusting Smartdown container grid height: need to populate SD content first!');
+    if (!gridCellDiv) {
+      console.log('Error in fitContent()... div not found: ', divID);
     }
     else {
-      var contentHeight = innerContainer.clientHeight;
-      if (enforceMaxHeight) {
-        var maxHeight = window.innerHeight;
-        if (contentHeight > maxHeight) {
-          contentHeight = maxHeight;
-        }
+      var innerContainerChildren = gridCellDiv.children;
+      // console.log('...innerContainerChildren', innerContainerChildren);
+      var sumHeight = 0;
+      var numInnerChildren = innerContainerChildren.length;
+      for (var i = 0; i < numInnerChildren; ++i) {
+        var innerChild = innerContainerChildren[i];
+        // console.log('...innerChild', innerChild, innerChild.clientHeight);
+        sumHeight += innerChild.clientHeight;
       }
-      var newHeight = Math.floor(contentHeight / rowHeight) + 1;
 
+      var newHeight = Math.floor(sumHeight / rowHeight) + 1;
+      if (maxRows && newHeight > maxRows) {
+        newHeight = maxRows;
+      }
+      // console.log('...fitContent', rowHeight, sumHeight, layoutElement.h, newHeight);
       layoutElement.h = newHeight;
       layoutElement.moved = true;
     }
@@ -227,110 +181,175 @@ function fitContent(layout, rowHeight) {
 }
 
 
-function applySmartdown(layout, contentItems, done) {
-  if (!contentItems || contentItems.length == 0) {
-    console.log('No smartdown content, please select smartdown files to display!')
-  }
-  else if (contentItems.length !== layout.length) {
-    var numOfSDContent = contentItems.length;
-    console.log('applySmartdown ERROR ... numOfSDContent !== layout.length', numOfSDContent, layout.length);
-  }
-  else {
-    var unresolvedItems = contentItems.length;
-    layout.forEach(function(layoutElement, layoutElementIndex) {
-      var divID = layoutElement.divID;
-      var div = document.getElementById(divID);
-      if (!div) {
-        console.log('applySmartdown ERROR ... div not found:', divID);
-      }
-      else {
-        var content = contentItems[layoutElementIndex];
-        // div.innerHTML = content;
-        smartdown.setSmartdown(content, div, function() {
-          smartdown.startAutoplay(div);
+function applySmartdown(loadedTableau, done) {
+  var loadedTableauCells = loadedTableau.layout.cells;
+  var unresolvedItems = loadedTableauCells.length;
+  loadedTableauCells.forEach(function(layoutElement, layoutElementIndex) {
+    var divID = layoutElement.divID;
+    var div = document.getElementById(divID);
+    if (!div) {
+      console.log('applySmartdown ERROR ... div not found:', divID);
+    }
+    else {
+      var content = layoutElement.content;
 
-          if (--unresolvedItems === 0) {
-            done();
-          }
-        });
-      }
-    });
-  }
+      smartdown.setSmartdown(content, div, function() {
+        smartdown.startAutoplay(div);
+
+        if (--unresolvedItems === 0) {
+          done();
+        }
+      });
+
+    }
+  });
 }
 
 
-function loadTableau(layoutURL, done) {
+
+function applyLayoutAndContentToTableau(layout, content, loadedTableau, done) {
+  var tableauCells = [];
+  content.forEach(function(contentElement, loadedElementIndex) {
+    var index = loadedElementIndex.toString();
+    var cellName = `Card${index}`;
+    var layoutElement = layout[loadedElementIndex];
+
+    var tableauCell = {
+      x: layoutElement.x,
+      y: layoutElement.y,
+      w: layoutElement.w,
+      h: layoutElement.h,
+      i: index,
+      name: cellName,
+      content: contentElement,
+      contentURL: null,
+      divID: 'smartdown-output' + index
+    };
+    tableauCells.push(tableauCell);
+  });
+  var tableau = {
+    layout: {
+      cells: tableauCells
+    }
+  };
+  done(tableau);
+}
+
+
+function applyLayoutToTableau(layout, rowHeight, loadedTableau, done) {
+  var loadedTableauCells = loadedTableau.layout.cells;
+
+  if (layout.length !== loadedTableauCells.length) {
+    console.log('layout.length !== loadedTableauCells.length', layout.length, loadedTableauCells.length);
+  }
+  else {
+    loadedTableauCells.forEach(function(loadedElement, loadedElementIndex) {
+      var layoutElement = layout[loadedElementIndex];
+      loadedElement.h = layoutElement.h;
+      loadedElement.w = layoutElement.w;
+      loadedElement.x = layoutElement.x;
+      loadedElement.y = layoutElement.y;
+    });
+    done();
+  }
+}
+
+// Should be called tab
+function loadTableauData(tableau, cardName, done) {
+  var cells = tableau.layout.cells;
+  var layout = [];
+  var cellsRemainingUntilDone = cells.length;
+  cells.forEach(function(cell, i) {
+    var index = i.toString();
+    var cellName = `Card${index}`;
+
+    if (cell.contentURL) {
+      var pathElements = cell.contentURL.split('/');
+      cellName = pathElements[pathElements.length - 1];
+    }
+    var layoutCell = {
+      x: cell.posX,
+      y: cell.posY,
+      w: cell.dimW,
+      h: cell.dimH,
+      i: index,
+      name: cellName,
+      content: cell.content || '',
+      contentURL: cell.contentURL,
+      divID: 'smartdown-output' + index
+    };
+    layout.push(layoutCell);
+
+    var contentURL = cell.contentURL;
+    if (contentURL && contentURL.length > 0) {
+      var contentReq = new XMLHttpRequest();
+      contentReq.addEventListener('load', function() {
+        layoutCell.content = this.responseText;
+        if (--cellsRemainingUntilDone === 0) {
+          let loadedTableau = {
+            layout: {
+              cells: layout
+            }
+          };
+          done(loadedTableau, cardName);
+        }
+      });
+      contentReq.open('GET', contentURL);
+      contentReq.send();
+    }
+    else {
+      if (--cellsRemainingUntilDone === 0) {
+        let loadedTableau = {
+          layout: {
+            cells: layout
+          }
+        };
+        done(loadedTableau, cardName);
+      }
+    }
+  });
+}
+
+
+function loadTableauFromURL(tableauURL, cardName, done) {
   var oReq = new XMLHttpRequest();
   oReq.addEventListener('load', function() {
     var tableau = jsyaml.safeLoad(this.responseText);
-    var cells = tableau.layout.cells;
-    var layout = [];
-    var content = [];
-    var cellsRemainingUntilDone = cells.length;
-    cells.forEach(function(cell, i) {
-      var index = i.toString();
-      var layoutCell = {
-        x: cell.posX,
-        y: cell.posY,
-        w: cell.dimW,
-        h: cell.dimH,
-        i: index,
-        contentURL: cell.contentURL,
-        divID: 'smartdown-output' + index
-      };
-      layout.push(layoutCell);
-
-      var contentValue = 'Not Yet Loaded';
-      content.push(contentValue);
-
-      var contentURL = cell.contentURL;
-      if (contentURL && contentURL.length > 0) {
-        var contentReq = new XMLHttpRequest();
-        contentReq.addEventListener('load', function(x) {
-          content[i] = this.responseText;
-          if (--cellsRemainingUntilDone === 0) {
-            done(layout, content);
-          }
-        });
-        contentReq.open('GET', contentURL);
-        contentReq.send();
-      }
-      else {
-        content[i] = '';
-        if (--cellsRemainingUntilDone === 0) {
-          done(layout, content);
-        }
-      }
-    });
+    done(tableau, cardName);
   });
-  oReq.open('GET', layoutURL);
+  oReq.open('GET', tableauURL);
   oReq.send();
 }
 
-function exportTableau(layout, content) {
+function exportTableau(tableau) {
   var layoutCells = [];
-  layout.forEach(function(cell, index) {
+  var layout = tableau.layout.cells;
+  layout.forEach(function(cell) {
     var layoutCell = {
       posX: cell.x,
       posY: cell.y,
       dimW: cell.w,
-      dimH: cell.h,
-      contentURL: cell.contentURL || ''
+      dimH: cell.h
     };
 
+    if (cell.contentURL && cell.contentURL.length > 0) {
+      layoutCell.contentURL = cell.contentURL;
+    }
+    else {
+      layoutCell.content = cell.content;
+    }
     layoutCells.push(layoutCell);
   });
 
-  var tableau = {
+  var tableauToExport = {
     layout: {
       cells: layoutCells
     }
   };
 
-  var yaml = jsyaml.dump(tableau);
-  console.log('exportTableau', yaml);
+  var yaml = jsyaml.dump(tableauToExport);
 
-
+  yaml += '\n';
   var filename = 'tableau.yaml';
   var yamlExportData =
     encodeURI('data:text/x-yaml;charset=utf-8,' + yaml);
@@ -345,260 +364,384 @@ function exportTableau(layout, content) {
 }
 
 
-function buildView(divId, initialLayout, initialContent=[], numCols=12, gridRowHeight=200) {
+function filesSelected(done) {
+  var loadedContent = [];
+
+  // !This is bad, how is a method within a view to know about DOM elements?!
+  var selectedFiles = document.getElementById('selectedFiles').files;
+  var numItemsLeft = selectedFiles.length;
+  function fileLoaded(index) {
+    return function(event) {
+      loadedContent[index] = event.target.result;
+      if (--numItemsLeft === 0) {
+        done(loadedContent);
+      }
+    };
+  }
+
+  for (var indexOfFile = 0; indexOfFile < selectedFiles.length; indexOfFile++) {
+    loadedContent.push('Waiting to be loaded with content asynchronously');
+    var reader = new FileReader();
+    reader.onloadend = fileLoaded(indexOfFile);
+    reader.readAsText(selectedFiles[indexOfFile]);
+  }
+}
+
+
+function parseHash(hash) {
+  hash = hash.replace(/#/g, '');
+  var hashElements = hash.split(/-/g);
+  var tableauName = hashElements[0];
+  var cardName = hashElements[1] || '';
+  return {
+    tableauName: tableauName,
+    cardName: cardName
+  };
+}
+
+
+function buildView(divId, initialTableau, numCols=12, gridRowHeight=200) {
   /*global Vue*/
   var view = new Vue({
-      el: '#' + divId,
-      created: function () {
-        if (window.gridHelperOptions) {
-          this.kioskMode = window.gridHelperOptions.kioskMode;
-          this.authorMode = window.gridHelperOptions.authorMode;
-          this.showSettings = this.authorMode;
-          this.draggable = this.authorMode;
-          this.resizable = this.authorMode;
-          this.tableaux = window.gridHelperOptions.tableaux || ['Welcome', 'Comic', 'Gallery'];
-          this.defaultTableauName = window.gridHelperOptions.defaultTableauName || this.tableaux[0] || 'Welcome';
-          this.locationHash = window.location.hash;
+    el: '#' + divId,
+
+    components: {
+      "GridLayout": GridLayout,
+      "GridItem": GridItem
+    },
+
+    data: {
+      layout: [],
+      tableau: {
+        layout: {
+          cells: []
+        }
+      },
+      currentTableauName: '',
+      rowHeight: gridRowHeight,
+      maxRows: 5,
+      numCols: numCols,
+      draggable: false,
+      resizable: false,
+      index: 0,
+      authorMode: true,
+      kioskMode: false,
+      defaultTableauName: 'Welcome',
+      tableaux: [],
+      locationHash: '',
+      focusedCardName: '',
+    },
+
+    created() {
+      if (window.gridHelperOptions) {
+        this.kioskMode = window.gridHelperOptions.kioskMode;
+        this.authorMode = window.gridHelperOptions.authorMode;
+        this.draggable = this.authorMode;
+        this.resizable = this.authorMode;
+        this.tableaux = window.gridHelperOptions.tableaux || availableTableaux;
+        this.defaultTableauName = window.gridHelperOptions.defaultTableauName || this.tableaux[0] || 'Welcome';
+      }
+      else {
+        this.tableaux = availableTableaux;
+        this.defaultTableauName = this.tableaux[0];
+      }
+      this.locationHash = window.location.hash;
+    },
+
+    mounted() {
+      window.addEventListener('resize', this.onResize);
+      var {tableauName, cardName} = parseHash(this.locationHash);
+
+      if (tableauName === '') {
+        this.loadHomeTableau(cardName);
+      }
+      else {
+        this.loadTableauByName(tableauName, cardName);
+      }
+    },
+
+    beforeDestroy() {
+      // Unregister the event listener before destroying this Vue instance
+      window.removeEventListener('resize', this.onResize);
+    },
+
+    computed: {
+    },
+
+    watch: {
+    },
+
+    methods: {
+      loadHomeTableau(cardName) {
+        var that = this;
+        if (initialTableau) {
+          this.loadTableauInline(initialTableau, cardName);
         }
         else {
-          this.tableaux = ['Welcome', 'Comic', 'Gallery'];
-          this.defaultTableauName = this.tableaux[0];
-          this.locationHash = window.location.hash;
+          this.loadTableauByName(this.defaultTableauName, cardName);
         }
       },
-      mounted: function() {
-        const that = this;
-        window.addEventListener('resize', that.onResize);
-        window.onhashchange = that.locationHashChanged;
-        //window.addEventListener('hashChange', that.locationHashChanged);
-        if (that.locationHash && that.locationHash.length !== 0) {
-          // User given a specific tableau to navigate to
-          var tableauName = that.locationHash.replace(/#/g, '');
-          that.loadTableau(tableauName);
-        }
-        else if (that.locationHash === '') {
-          // User did not provide any tableau to load, use default or debug content
-          if (initialContent && initialLayout) {
-            this.sdContent = initialContent;
-            this.layout = initialLayout;
-            this.applyContentAndFixLayout();
-            //this.locationHash = '#Debug';
-            //window.location.hash = this.locationHash;
-          }
-          else {
-            that.loadTableau(that.defaultTableauName);
-          }
-        }
-      },
-      beforeDestroy() {
-        // Unregister the event listener before destroying this Vue instance
-        window.removeEventListener('resize', this.onResize)
-      },
-      components: {
-        "GridLayout": GridLayout,
-        "GridItem": GridItem
-      },
-      data: {
-        layout: [],
-        rowHeight: gridRowHeight,
-        numCols: numCols,
-      	sdContent: [],
-        draggable: true, //this.authorMode,
-        resizable: true, //this.authorMode,
-        index: 0,
-        authorMode: false,
-        showSettings: true, //this.authorMode,
-        kioskMode: false,
-        defaultTableauName: 'Welcome',
-        tableaux: [],
-        currentTableauName: '',
-        locationHash: '',
-        focusedCardName: '',
-      },
-      computed: {
-      },
-      watch: {
-      },
-      methods: {
-        onResize(event) {
-          var that = this;
-          this.$nextTick(function () {
-            that.fixLayout();
-          });
-        },
-        isDragging: function() {
-          return this.$refs.layout ?
-            this.$refs.layout.isDragging :
-            false;
-        },
-        loadTableau: function(name) {
-          var that = this;
-          loadTableau('tableaux/' + name.toLowerCase() + '.yaml', function(layout, sdContent) {
-            that.layout = layout;
-            that.sdContent = sdContent;
-            that.applyContentAndFixLayout();
-          });
-          that.locationHash = '#' + name;
-          window.location.hash = that.locationHash;
-          that.currentTableauName = name;
-        },
-        isCurrentTableau: function(tableauName) {
-          return this.currentTableauName === tableauName;
-        },
-        isSdTileInFocus: function(cardName) {
-          return this.focusedCardName === cardName;
-        },
-        focusOnCard: function(cardName) {
-          this.focusedCardName = cardName;
-          if (this.locationHash.indexOf('-') > -1) {
-            this.locationHash = this.locationHash.split('-')[0] + '-' + cardName;
-          }
-          else {
-            this.locationHash = this.locationHash + '-' + cardName;
-          }
-          window.location.hash = this.locationHash;
-        },
-        locationHashChanged: function() {
-          if (this.locationHash !== window.location.hash && window.location.hash) {
-            console.log(`location hash changed to ${window.location.hash}`);
-            if (window.location.hash.indexOf('-') > -1) {
-              // user given both tableau name and card name
-              // hash format: #tableauName-cardName
-              console.log('location hash has -');
-              var tableauName = window.location.hash.split('-')[0];
-              tableauName = tableauName.replace(/#/g, '');
-              console.log(`tableauName is ${tableauName}`);
-              if (this.tableaux.indexOf(tableauName) > -1) {
-                console.log(`Loading tableau ${tableauName}`);
-                var cardName = window.location.hash.split('-')[1];
-                this.loadTableau(tableauName);
-                console.log(`cardName is ${cardName}`);
-                this.focusOnCard(cardName);
-                /*
-                var cardDivsOnPage = document.querySelectorAll('[id*="smartdown-output"]');
-                var cardDivNamesOnPage = [];
-                for (var cardDiv of cardDivsOnPage) {
-                  var cardURL = cardDiv.contentURL; //This when loaded from tableau is in the format of 'tableaux/cardName.md'
-                  var cardName = cardURL.split('/')[1]
-                  cardDivNamesOnPage.push(cardName);
-                }
-                if (cardDivNamesOnPage.indexOf(cardName) > -1) {
-                  this.focusedCardName = cardName;
-                }
-                */
 
-              }
-              else {
-                console.log(`The tableau you tried to load does not exist! Available tableaux are ${this.tableaux.toString()}`)
-              }
-            }
-            else if (window.location.hash.indexOf('-') === -1) {
-              // user only given tableau name to load
-              var tableauName = window.location.hash.replace(/#/g, '');
-              if (this.tableaux.indexOf(tableauName) > -1) {
-                this.loadTableau(tableauName);
-              }
-              else {
-                console.log(`The tableau you tried to load does not exist! Available tableaux are ${this.tableaux.toString()}`)
-              }
-            }
-          }
-        },
-        exportTableau: function() {
-          exportTableau(this.layout, this.sdContent);
-        },
-        applyContentAndFixLayout: function() {
-          var that = this;
-          that.$nextTick(function () {
-            applySmartdown(that.layout, that.sdContent, function() {
+      loadTableauInline(tableau, cardName) {
+        this.loadTableauData(tableau, '', cardName);
+      },
+
+      loadTableauByName(tableauName, cardName) {
+        var that = this;
+
+        loadTableauFromURL('tableaux/' + tableauName.toLowerCase() + '.yaml', cardName, function(tableau, cardName) {
+          that.loadTableauData(tableau, tableauName, cardName);
+        });
+      },
+
+      loadTableauData(tableau, tableauName, cardName) {
+        var that = this;
+
+        loadTableauData(tableau, cardName, function(loadedTableau, cardName) {
+          that.tableau = loadedTableau;
+          that.currentTableauName = tableauName;
+          that.focusOnCard(cardName);
+
+          that.$nextTick(function() {
+            applySmartdown(loadedTableau, function() {
               that.fixLayout();
             });
           });
-        },
-        fixLayout: function() {
-          var that = this;
-          fitContent(that.layout, that.rowHeight);
-          that.$nextTick(function () {
-            that.$refs.layout.lastLayoutLength = 0;
-            that.$refs.layout.layoutUpdate();
-            window.setTimeout(function () {
-              fitContent(that.layout, that.rowHeight);
-              that.$refs.layout.onWindowResize();
-              that.$refs.layout.updateHeight();
-            }, 1000);
-          });
-        },
-        switchToColumnLayout: function() {
-          this.layout = buildColumnLayout(this.sdContent.length, this.numCols);
-          this.fixLayout();
-        },
+        });
+      },
 
-        switchToRowLayout: function() {
-          this.layout = buildRowLayout(this.sdContent.length, this.numCols);
-          this.fixLayout();
-        },
+      onResize() {
+        var that = this;
+        this.$nextTick(function () {
+          that.fixLayout();
+        });
+      },
 
-	      updateSdSelection: function() {
-          this.sdContent = [];
-          var that = this;
-	        updateSdSelection(this.sdContent, function() {
-            that.layout = buildRowLayout(that.sdContent.length, that.numCols);
-            that.$nextTick(function () {
-              window.location.hash = ''; //when loading files from fileReader, there's no location hash
-              that.currentTableauName = '';
-              applySmartdown(that.layout, that.sdContent, function() {
+      isDragging() {
+        return this.$refs.layout ?
+          this.$refs.layout.isDragging :
+          false;
+      },
+
+      isCurrentTableau(tableauName) {
+        return this.currentTableauName === tableauName;
+      },
+
+      isCardFocused(cardName) {
+        return this.focusedCardName === cardName;
+      },
+
+      focusOnCard(cardName) {
+        this.focusedCardName = cardName;
+        if (!cardName || cardName === '') {
+          this.locationHash = this.currentTableauName;
+        }
+        else {
+          this.locationHash = this.currentTableauName + '-' + cardName;
+        }
+        window.location.hash = this.locationHash;
+      },
+
+      toggleFocusOnCard(cardName) {
+        if (this.isCardFocused(cardName)) {
+          this.focusOnCard('');
+        }
+        else {
+          this.focusOnCard(cardName);
+        }
+      },
+
+      toggleAuthorMode() {
+        var that = this;
+        this.authorMode = !this.authorMode;
+        this.draggable = this.resizable = this.authorMode;
+      },
+
+      exportTableau() {
+        exportTableau(this.tableau);
+      },
+
+      fixLayout() {
+        var that = this;
+        fitContent(that.tableau, that.rowHeight, that.maxRows);
+        that.$nextTick(function () {
+          that.$refs.layout.lastLayoutLength = 0;
+          that.$refs.layout.layoutUpdate();
+          window.setTimeout(function () {
+            fitContent(that.tableau, that.rowHeight, that.maxRows);
+            that.$refs.layout.onWindowResize();
+            that.$refs.layout.updateHeight();
+          }, 2000);
+        });
+      },
+
+
+      applyLayoutToTableau(layout) {
+        var that = this;
+        applyLayoutToTableau(layout, this.rowHeight, this.tableau, function() {
+          that.fixLayout();
+        });
+      },
+
+      switchToColumnLayout() {
+        // var layout = buildColumnLayout(this.tableau.layout.cells.length, this.numCols);
+        var layout = buildLayout(this.tableau.layout.cells.length,
+          3, 0, 3, 0, 1, 1);
+        //xDelta, yDelta, width, widthDelta, height, heightDelta
+
+        this.applyLayoutToTableau(layout);
+      },
+
+      switchToRowLayout() {
+        var layout = buildLayout(this.tableau.layout.cells.length,
+          0, 1, this.numCols, 0, 1, 0);
+        //xDelta, yDelta, width, widthDelta, height, heightDelta
+        this.applyLayoutToTableau(layout);
+      },
+
+      switchToStaggeredLayout() {
+        var layout = buildLayout(this.tableau.layout.cells.length,
+          1, 1, this.numCols, -1, 1, 0);
+        //xDelta, yDelta, width, widthDelta, height, heightDelta
+        this.applyLayoutToTableau(layout);
+      },
+
+      switchToXLayout() {
+        var numContent = this.tableau.layout.cells.length;
+        if ((numContent - 1) % 4 === 0) {
+          var layout = buildXLayout(numContent);
+          this.applyLayoutToTableau(layout);
+        }
+      },
+
+      filesSelected() {
+        var that = this;
+        filesSelected(function(loadedContent) {
+          var layout = buildLayout(loadedContent.length,
+            1, 1, this.numCols, -1, 1, 0);
+          //xDelta, yDelta, width, widthDelta, height, heightDelta
+
+          applyLayoutAndContentToTableau(layout, loadedContent, that.tableau, function(tableau) {
+            that.tableau = tableau;
+            that.currentTableauName = '';
+            that.locationHash = '';
+            window.location.hash = '';
+            that.$nextTick(function() {
+              applySmartdown(tableau, function() {
                 that.fixLayout();
               });
             });
           });
-	      },
+        });
+      },
 
-        resizeEvent: function(i, newH, newW){
-          // console.log("RESIZE i=" + i + ", H=" + newH + ", W=" + newW);
-        },
-        resizedEvent: function(i, newH, newW, newHPx, newWPx){
-          const that = this;
-          console.log("RESIZED");
-          if (!that.authorMode) {
-            this.$nextTick(function () {
-              that.fixLayout();
-            });
-          }
-        },
-        dragStart: function(){
-          console.log("dragStart");
-        },
-        resizeStart: function(){
-          console.log("resizeStart", this);
-        },
+      resizedEvent(i, newH, newW, newHPx, newWPx) {
+        this.fixLayout();
+      },
 
+      dragStart() {
+        // console.log("dragStart");
+      },
+
+      resizeStart() {
+        // console.log("resizeStart", this);
       }
+
+    }
   });
 
   return view;
 }
 
 
-/* eslint-disable */
-/* global smartdown */
 var baseURL = 'https://smartdown.site/'; //'https://127.0.0.1:4000/';
 var svgIcons = {
 };
 
+
+
+var debugCard0 =
+`
+# Debug Card 0
+
+Simple Card
+
+- [Card1](:@Card1)
+- [Card2](:@Card2)
+
+`;
+
+var debugCard1 =
+`
+# Debug Card 1
+
+[What is your name?](:?Name)
+
+![](http://www.eugeneweekly.com/sites/default/files/uploads/imported/2009/graphics/032609somethingeug.jpg)
+`;
+
+var debugCard2 =
+`
+# Debug Card 2
+
+## FixFontSizeForOutputCells, [](:!Name)
+
+### FixFontSizeForOutputCells, [](:!Name)
+
+#### FixFontSizeForOutputCells, [](:!Name)
+
+##### FixFontSizeForOutputCells, [](:!Name)
+
+###### FixFontSizeForOutputCells, [](:!Name)
+`;
+
+
+var debugTableau = {
+  layout: {
+    cells: [
+      {
+        posX: 0,
+        posY: 0,
+        dimW: 12,
+        dimH: 3,
+        content: debugCard0
+      },
+      {
+        posX: 0,
+        posY: 3,
+        dimW: 6,
+        dimH: 3,
+        content: debugCard1
+      },
+      {
+        posX: 6,
+        posY: 3,
+        dimW: 6,
+        dimH: 3,
+        content: debugCard2
+      }
+    ]
+  }
+};
+
+var vueApp = null;
+
+function cardLoader(cardName) {
+  console.log('cardloader', cardName, vueApp);
+  vueApp.focusOnCard(cardName);
+}
+
 function smartdownLoaded() {
-  var debugLayout = debugContent ?
-    buildColumnLayout(debugContent.length, numColumns) :
-    null;
-  // debugLayout = buildStaggeredLayout(3, numColumns);
-  debugLayout = null;
-  gridView = buildView(vueAppDivId, debugLayout, debugContent, 12, defaultRowHeight);
+  debugTableau = null;
+  vueApp = buildView(vueAppDivId, debugTableau, 12, defaultRowHeight);
 }
 
 var calcHandlers = null;
 const linkRules = [
 ];
 
-smartdown.initialize(svgIcons, baseURL, smartdownLoaded, null, calcHandlers, linkRules);
+
+smartdown.initialize(svgIcons, baseURL, smartdownLoaded, cardLoader, calcHandlers, linkRules);
 
 /*
 function navigateToCard(cardName) {

--- a/index.html
+++ b/index.html
@@ -27,125 +27,144 @@
         id="layoutApp">
 
         <div
-          class="layoutJSON">
+          class="navigationArea">
           <div class="row">
-            <div class="col-xs-9">
-              <input type="checkbox" v-model="kioskMode"/> kioskMode
-              <input type="checkbox" v-model="authorMode"/> authorMode
+            <div class="col-xs-10">
               <button
                 v-for="t in tableaux"
                 class="btn btn-default btn-xs tableau-button"
                 v-bind:class="{ current: isCurrentTableau(t) }"
-                v-on:click="loadTableau(t)">
+                v-bind:disabled="isCurrentTableau(t)"
+                v-on:click="loadTableauByName(t)">
                 {{t}}
               </button>
             </div>
-            <div class="col-xs-3" v-if="!kioskMode">
-              <input type="checkbox" v-model="showSettings"/>&nbsp;Settings
-            </div>
-            <div class="col-xs-9" v-if="kioskMode&!authorMode">
+
+            <div class="col-xs-2">
               <button
-                v-for="item in layout"
+                class="btn btn-default btn-xs"
+                v-on:click="loadHomeTableau()">
+                Home
+              </button>
+            </div>
+
+            <div class="col-xs-10">
+              <button
+                v-for="item in tableau.layout.cells"
                 class="btn btn-default btn-xs card-button"
-                v-bind:class="{ focused: isSdTileInFocus(item.contentURL.split('/')[1]) }"
-                v-on:click="focusOnCard(item.contentURL.split('/')[1])">
-                {{item.contentURL.split('/')[1]}}
+                v-bind:class="{ focused: isCardFocused(item.name) }"
+                v-on:click="toggleFocusOnCard(item.name)">
+                {{item.name}}
+              </button>
+            </div>
+            <div class="col-xs-2">
+              <button
+                class="btn btn-default btn-xs card-button"
+                v-on:click="focusOnCard('')">
+                None
               </button>
             </div>
           </div>
-          <div class="row" v-if="showSettings">
+        </div>
+
+        <div
+          v-if="!kioskMode"
+          class="authorArea"
+          @dblclick="toggleAuthorMode()">
+          <div class="row" v-if="authorMode">
+            <div class="col-xs-8">
+              <input
+                type="file"
+                id="selectedFiles"
+                accept=".md"
+                v-on:change="filesSelected"
+                multiple/>
+            </div>
             <div class="col-xs-4">
-              <div class="layoutItem" v-for="item in layout">
+              <button class="btn btn-default btn-xs" v-on:click="exportTableau">Export Tableau</button>
+            </div>
+            <div class="col-xs-12">
+              <button class="btn btn-default btn-xs" v-on:click="switchToColumnLayout">Column Layout</button>
+              <button class="btn btn-default btn-xs" v-on:click="switchToRowLayout">Row Layout</button>
+              <button class="btn btn-default btn-xs" v-on:click="switchToStaggeredLayout">Staggered Layout</button>
+              <button class="btn btn-default btn-xs" v-on:click="switchToXLayout">X Layout</button>
+            </div>
+          </div>
+          <div class="row" v-if="authorMode">
+            <div class="col-xs-12">
+              <div class="layoutItem" v-for="item in tableau.layout.cells">
                   <b>{{item.i}}</b>: [{{item.x}}, {{item.y}}, {{item.w}}, {{item.h}}]
               </div>
-            </div>
-            <div class="col-xs-8">
-              <div class="row">
-                <div class="col-xs-12" v-if="authorMode&!kioskMode">
-                  <input
-                    type="file"
-                    id="sdSelection"
-                    accept=".md"
-                    v-on:change="updateSdSelection"
-                    multiple/>
-                </div>
-              </div>
-              <div class="row">
-                <div class="col-xs-12">
-                  <button class="btn btn-default btn-xs" v-on:click="switchToColumnLayout">Column Layout</button>
-                  <button class="btn btn-default btn-xs" v-on:click="switchToRowLayout">Row Layout</button>
-                  <button class="btn btn-default btn-xs" v-on:click="exportTableau">Export Tableau</button>
-                </div>
-              </div>
-              <div class="row">
-                <div class="col-xs-8">
-                  <input type="checkbox" v-model="draggable"/> Draggable
-                  <input type="checkbox" v-model="resizable"/> Resizable
-                </div>
-
-                <div class="col-xs-4">
-                  <button class="btn btn-default btn-xs" v-on:click="fixLayout">Fix</button>
-                </div>
-
-              </div>
-
-
             </div>
           </div>
         </div>
 
         <div id="content" class="smartdown-container">
           <grid-layout  ref="layout"
-                        :layout="layout"
+                        :layout="tableau.layout.cells"
                         :col-num="numCols"
                         :row-height="rowHeight"
-                        :margin="[3, 3]"
+                        :margin="[5, 5]"
                         :is-draggable="draggable"
                         :is-resizable="resizable"
                         :vertical-compact="true"
                         :use-css-transforms="true">
-            <grid-item  v-for="item in layout" :key="item.i"
-                        :x="item.x"
-                        :y="item.y"
-                        :w="item.w"
-                        :h="item.h"
-                        :i="item.i"
-                        @resize="resizeEvent"
-                        @resized="resizedEvent"
-                        drag-allow-from=".vue-draggable-handle"
-                        drag-ignore-from=".no-drag">
+            <grid-item
+              v-for="item in tableau.layout.cells"
+              :key="item.i"
+              :x="item.x"
+              :y="item.y"
+              :w="item.w"
+              :h="item.h"
+              :i="item.i"
+              v-bind:class="{ 'in-focus': isCardFocused(item.name) }"
+              @resized="resizedEvent"
+              drag-allow-from=".vue-draggable-handle"
+              drag-ignore-from=".no-drag">
 
               <div
-                v-if="draggable"
                 class="vue-draggable-handle"
+                v-bind:class="{ 'hide-draggable': !draggable }"
                 v-on:click="dragStart">
               </div>
+
+<!--
+  work in progress to create a smartdown component and simplify applySmartdown()
+  and fitContent(). See grid_helper.js for more info.
+
+              <smartdown
+                class="no-drag smartdown-tile"
+                v-bind:class="{ 'in-focus': isCardFocused(item.name) }"
+                v-bind:id="item.divID"
+                :content="item.content">
+              </smartdown>
+ -->
+
               <div
                 class="no-drag smartdown-tile"
-                v-bind:id="item.divID"
-                v-bind:class="{ 'in-focus': isSdTileInFocus(item.contentURL.split('/')[1]) }">
+                v-bind:id="item.divID">
               </div>
             </grid-item>
           </grid-layout>
       </div>
     </div>
 
-    <script>
-      //
-      // The options below control how the grid_helper behaves.
-      // They are designed to support publishing via bl.ocks.org, a blog, or Wordpress
-      //
-      //  kioskMode - 'true' means disable the Settings checkbox
-      //  tableaux - A list of names of tableaux in the tableaux/ directory
-      //  defaultTableauName - The tableau to load by default. Default is tableaux[0]
-      //
-      window.gridHelperOptions = {
-        kioskMode: true,
-        authorMode: false,
-        tableaux: ['Comic', 'Welcome'],
-        defaultTableauName: 'Comic',
-      };
-    </script>
+<script>
+//
+// The options below control how the grid_helper behaves.
+// They are designed to support publishing via bl.ocks.org, a blog, or Wordpress
+//
+//  kioskMode - 'true' means disable the Settings checkbox
+//  tableaux - A list of names of tableaux in the tableaux/ directory
+//  defaultTableauName - The tableau to load by default. Default is tableaux[0]
+//
+window.gridHelperOptions = {
+  kioskMode: false,
+  authorMode: false,
+  tableaux: ['Welcome', 'Comic', 'Gallery', 'WebGL', 'Pegoda'],
+  defaultTableauName: 'Welcome',
+};
+</script>
     <script src="grid_helper.js"></script>
   </body>
 </html>

--- a/tableaux/gallery.yaml
+++ b/tableaux/gallery.yaml
@@ -1,15 +1,15 @@
 layout:
   cells:
     - posX: 0
-      posY: 21
-      dimW: 6
-      dimH: 12
-      contentURL: 'https://smartdown.site/lib/gallery/Three.md'
-    - posX: 0
       posY: 0
       dimW: 12
       dimH: 21
       contentURL: 'https://smartdown.site/lib/gallery/Math.md'
+    - posX: 0
+      posY: 21
+      dimW: 6
+      dimH: 12
+      contentURL: 'https://smartdown.site/lib/gallery/D3.md'
     - posX: 0
       posY: 33
       dimW: 6

--- a/tableaux/pegoda.yaml
+++ b/tableaux/pegoda.yaml
@@ -1,0 +1,26 @@
+layout:
+  cells:
+    - posX: 0
+      posY: 0
+      dimW: 7
+      dimH: 4
+      content: >-
+        ![](http://eugeneweekly.com/sites/default/files/uploads/20141106euge.jpg)
+        [Something Euge -
+        11-6-2014](http://eugeneweekly.com/image/something-euge-11-6-14)
+    - posX: 7
+      posY: 0
+      dimW: 5
+      dimH: 3
+      content: >-
+        ![](http://www.eugeneweekly.com/sites/default/files/uploads/20170112euge-snowtweet.jpg)
+        [Something Euge -
+        1-12-2017](http://www.eugeneweekly.com/image/something-euge-2017-1-12)
+    - posX: 7
+      posY: 3
+      dimW: 5
+      dimH: 2
+      content: >-
+        ![](http://www.eugeneweekly.com/sites/default/files/uploads/imported/2009/graphics/032609somethingeug.jpg)
+        [Something Euge -
+        3-26-2009](http://www.eugeneweekly.com/2009/03/26/news.html#eug)

--- a/tableaux/webgl.yaml
+++ b/tableaux/webgl.yaml
@@ -1,0 +1,17 @@
+layout:
+  cells:
+    - posX: 0
+      posY: 0
+      dimW: 6
+      dimH: 3
+      contentURL: tableaux/webgl1.md
+    - posX: 0
+      posY: 3
+      dimW: 6
+      dimH: 3
+      contentURL: 'https://smartdown.site/lib/gallery/Three.md'
+    - posX: 6
+      posY: 0
+      dimW: 6
+      dimH: 9
+      contentURL: 'https://smartdown.site/lib/gallery/Mobius.md'

--- a/tableaux/webgl1.md
+++ b/tableaux/webgl1.md
@@ -1,0 +1,7 @@
+### WebGL Examples
+
+These examples may not work in older browsers that do not support WebGL or on computers without modern graphics card.
+
+Try this tableau in a different browser, or try enabling WebGL using the instructions here:
+
+- [How can I enable WebGL in my browser?](https://superuser.com/questions/836832/how-can-i-enable-webgl-in-my-browser)

--- a/tableaux/welcome1.md
+++ b/tableaux/welcome1.md
@@ -2,57 +2,43 @@
 
 Smartdown Tableaux provides an additional way to present Smartdown content by allowing Smartdown documents (aka Cards) to be organized into a two-dimensional layout.
 
-```p5js/playable/autoplay
-var PI = Math.PI;
-var HALF_PI = PI / 2.0;
+---
 
-smartdown.setVariable('SEGMENTS', 30, 'number');
-smartdown.setVariable('SEG_WIDTH', 8, 'number');
-smartdown.setVariable('SEG_LENGTH', 50, 'number');
+Vector Field Example Based upon https://github.com/winkerVSbecks/material-vector-field
 
-var speed = 0.05;
-var ax = .01;
-var ay = ax;
-var az = ay;
-var dx, dy, dz;
+```p5js/playable
 
-p5.windowResized = function() {
-  p5.resizeCanvas(p5.windowWidth / 3, p5.windowWidth / 3);
-};
+var locs = [];
+function calcVec(x, y) {
+  return new P5.Vector(y - x, - x - y);
+}
 
 p5.setup = function() {
-  dx = p5.random(-speed, speed);
-  dy = p5.random(-speed, speed);
-  dz = p5.random(-speed, speed);
+  p5.createCanvas(300, 300);
 
-  p5.createCanvas(300, 300, 'webgl');
-  p5.normalMaterial();
+  var res = 20;
+  var countX = p5.ceil(p5.width/res) + 1;
+  var countY = p5.ceil(p5.height/res) + 1;
 
-  p5.windowResized();
+  for (var j = 0; j < countY; j++) {
+    for (var i = 0; i < countX; i++) {
+      locs.push( new P5.Vector(res*i, res*j) );
+    }
+  };
+
+  p5.noFill();
+  p5.stroke(249, 78, 128);
+
 };
-
 p5.draw = function() {
-  var SEGMENTS = env.SEGMENTS;
-  var SEG_WIDTH = env.SEG_WIDTH;
-  var SEG_LENGTH = env.SEG_LENGTH;
-  var DIAMETER = SEG_LENGTH * 2;
-  p5.background('ivory');
-  p5.camera(0, SEG_LENGTH, p5.windowHeight / 3, 0, 0, 0, 0, 1, 0);
-  p5.rotateX(ax += dx);
-  p5.rotateY(ay += dy);
-  p5.rotateZ(az += dz);
-
-  for (var i = 0; i < SEGMENTS; i++) {
-    var frac = i * 2 / SEGMENTS;
+  p5.background(30, 67, 137);
+  for (var i = locs.length - 1; i >= 0; i--) {
+    var h = calcVec( locs[i].x - p5.mouseX, locs[i].y - p5.mouseY);
     p5.push();
-    p5.rotateX(frac * HALF_PI);
-    p5.rotateY(HALF_PI);
-    p5.translate(
-        0,
-        DIAMETER * p5.cos(frac * HALF_PI),
-        DIAMETER * p5.sin(frac * PI));
-    p5.cylinder(SEG_WIDTH, SEG_LENGTH);
+      p5.translate(locs[i].x, locs[i].y);
+      p5.rotate(h.heading());
+      p5.line(0, 0, 0, - 15);
     p5.pop();
-  }
+  };
 };
 ```

--- a/vuegridlayout.css
+++ b/vuegridlayout.css
@@ -16,34 +16,51 @@ div#layoutApp {
   padding: 0;
 }
 
-div#layoutApp .layoutJSON {
+div#layoutApp .navigationArea {
   background: aliceblue;
   width: 100%;
   padding: 5px 15px;
   margin: 0;
+  border: 1px solid lightgray;
+  border-radius: 3px;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
-.layoutJSON button.tableau-button {
+div#layoutApp .navigationArea button.tableau-button {
   margin: 5px 10px;
   padding: 2px 5px;
 }
 
-.layoutJSON button.tableau-button.current {
+div#layoutApp .navigationArea button.tableau-button.current {
   background: yellow;
   margin: 2px 5px;
   padding: 5px 10px;
 }
 
-.layoutJSON button.card-button {
+div#layoutApp .navigationArea button.card-button {
   margin: 2px 5px;
   padding: 1px 3px;
 }
 
-.layoutJSON button.card-button.focused {
+div#layoutApp .navigationArea button.card-button.focused {
   background: yellow;
   margin: 1px 3px;
   padding: 2px 5px;
 }
+
+
+div#layoutApp .authorArea {
+  background: aliceblue;
+  width: 100%;
+  padding: 5px 15px;
+  margin: 0;
+  user-select: none;
+  -webkit-user-select: none;
+  border: 1px solid lightgray;
+  border-radius: 3px;
+}
+
 
 input#sdSelection {
 }
@@ -61,82 +78,30 @@ div#layoutApp.disable-select * {
 }
 
 div#layoutApp .vue-grid-layout {
-  background: darkgray;
+  background: steelblue;
   margin: 0;
   padding: 0;
 }
 
 div#layoutApp .vue-grid-layout .vue-grid-item {
-  background: #eee;
-  margin: 0;
+  background: ghostwhite;
+  padding: 0 0 20px 0;
   width: 100%;
   height: 100%;
 }
 
-div#layoutApp .vue-grid-layout .vue-grid-item:not(.vue-grid-placeholder) {
-  background: transparent;
-  border: 1px solid white;
-  padding: 0;
-  margin: 0;
+div#layoutApp .vue-grid-layout .vue-grid-item.in-focus {
+  box-shadow: inset 3px -3px 0.5em lightgreen;
 }
 
-div#layoutApp .vue-grid-layout .vue-grid-item.resizing {
-  opacity: 0.9;
-}
 
-div#layoutApp .vue-grid-layout .vue-grid-item.static {
-  background: #cce;
-}
-
-div#layoutApp .vue-grid-layout .vue-grid-item .text {
-  font-size: 24px;
-  text-align: center;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  margin: auto;
-  height: 100%;
+div.smartdown-tile {
+  margin: 10px 0;
+  padding: 0 10px;
   width: 100%;
-}
-
-div#layoutApp .vue-grid-layout .vue-grid-item .no-drag {
   height: 100%;
-  width: 100%;
-}
-
-div.no-drag.smartdown-tile {
-  background: lightgrey;/*ghostwhite;*/
-  margin: 0;
-  padding: 5px;
-  overflow-y: auto;
   overflow-x: hidden;
-}
-
-div.no-drag.smartdown-tile.in-focus {
-  background: white;
-  margin: 0;
-  padding: 0px;
-  border: 1px red;
   overflow-y: auto;
-  overflow-x: hidden;
-}
-
-div.no-drag.smartdown-tile:empty {
-  background: white; /* For browsers that do not support gradients */
-  background: -webkit-linear-gradient(left top, white, lightgray); /* For Safari 5.1 to 6.0 */
-  background: -o-linear-gradient(bottom right, white, lightgray); /* For Opera 11.1 to 12.0 */
-  background: -moz-linear-gradient(bottom right, white, lightgray); /* For Firefox 3.6 to 15 */
-  background: linear-gradient(to bottom right, white, lightgray); /* Standard syntax */
-}
-
-div#layoutApp .vue-grid-layout .vue-grid-item .minMax {
-  font-size: 12px;
-}
-
-div#layoutApp .vue-grid-layout .vue-grid-item .add {
-  cursor: pointer;
 }
 
 div#layoutApp .vue-grid-layout .vue-grid-item > .vue-resizable-handle {
@@ -162,17 +127,19 @@ div#layoutApp .vue-grid-layout .vue-draggable-handle {
   width: 100%;
   height: 10px;
 
-  background: darkslateblue; /* For browsers that do not support gradients */
-  background: -webkit-linear-gradient(lightblue, darkslateblue); /* For Safari 5.1 to 6.0 */
-  background: -o-linear-gradient(lightblue, darkslateblue); /* For Opera 11.1 to 12.0 */
-  background: -moz-linear-gradient(lightblue, darkslateblue); /* For Firefox 3.6 to 15 */
-  background: linear-gradient(lightblue, darkslateblue); /* Standard syntax */
+  background: darkslateblue;
+  background: -webkit-linear-gradient(lightblue, darkslateblue);
+  background: -o-linear-gradient(lightblue, darkslateblue);
+  background: -moz-linear-gradient(lightblue, darkslateblue);
+  background: linear-gradient(lightblue, darkslateblue);
 
   box-sizing: border-box;
   cursor: pointer;
 }
 
-.smartdown-container > div {
+
+div#layoutApp .vue-grid-layout .hide-draggable {
+  display: none;
 }
 
 .layoutItem {


### PR DESCRIPTION
- Significantly refactored grid_helper.js to DRY it up and make it more maintainable and understandable.
- Also cleaned up styling in many places and eliminated many of the debugging artificts and controls we were using.
- Hooked up the Smartdown cardLoader callback to change the focused card.
- Added additional examples, and isolated the WebGL examples into their own tableau.
- Simplified row/column/staggered layout to use a generalized layout function.
- Added an X layout.
- Fix Export Tableau to support the .content field as well as the .contentURL field.
