### PR TITLE
Export Tableau works in Firefox. Choose Files works with .md and .yaml.

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
               <input
                 type="file"
                 id="selectedFiles"
-                accept=".md"
+                accept=".md,.yaml"
                 v-on:change="filesSelected"
                 multiple/>
             </div>


### PR DESCRIPTION
- Fix data URI encoding so that Export Tableau works in all browsers, including Firefox.
- Allow for Choose Files to select zero-or-more .md files and one .yaml tableau file.